### PR TITLE
Add strict mode to all src files

### DIFF
--- a/src/MoronEagerFetcher.js
+++ b/src/MoronEagerFetcher.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash')
   , Promise = require('bluebird')
   , MoronQueryBuilder = require('./MoronQueryBuilder')

--- a/src/MoronModel.js
+++ b/src/MoronModel.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , utils = require('./moronUtils')
@@ -1168,11 +1168,11 @@ MoronModel.$$omitRelations = function (json) {
   if (!this.$$omitAttributes) {
     this.$$omitAttributes = _.keys(this.getRelations());
   }
-  
+
   if (this.$$omitAttributes.length) {
     return _.omit(json, this.$$omitAttributes);
   }
-  
+
   return json;
 };
 

--- a/src/MoronQueryBuilder.js
+++ b/src/MoronQueryBuilder.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , Promise = require('bluebird')

--- a/src/MoronRelationExpression.js
+++ b/src/MoronRelationExpression.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash')
   , MoronValidationError = require('./MoronValidationError');
 

--- a/src/MoronValidationError.js
+++ b/src/MoronValidationError.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var util = require('util');
 
 /**
@@ -6,7 +8,7 @@ var util = require('util');
  */
 function MoronValidationError(data) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, MoronValidationError);
 
   this.data = data;
   this.statusCode = 400;

--- a/src/moronTransaction.js
+++ b/src/moronTransaction.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash');
 var Promise = require('bluebird');
 var MoronModel = require('./MoronModel');

--- a/src/moronUtils.js
+++ b/src/moronUtils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash')
   , util = require('util');
 

--- a/src/relations/MoronManyToManyRelation.js
+++ b/src/relations/MoronManyToManyRelation.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , MoronRelation = require('./MoronRelation')

--- a/src/relations/MoronOneToManyRelation.js
+++ b/src/relations/MoronOneToManyRelation.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , MoronRelation = require('./MoronRelation');

--- a/src/relations/MoronOneToOneRelation.js
+++ b/src/relations/MoronOneToOneRelation.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , MoronRelation = require('./MoronRelation');

--- a/src/relations/MoronRelation.js
+++ b/src/relations/MoronRelation.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
   , utils = require('../moronUtils')


### PR DESCRIPTION
MoronValidationError stack trace logging format migrated from
old ECMAScript `arguments.callee` style self referencing to
new named function referencing for strict mode compatibility.

Please refer to Mozilla documentation for `arguments.callee`:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee

This pull request resolves #2 and includes syntax clean up.