### PR TITLE
Enable running integration tests with other databases, even if one does not exist

### DIFF
--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var os = require('os');
 var path = require('path');
+var Promise = require('bluebird');
 var modelTestUtils = require('./utils');
 
 describe('integration tests', function () {
@@ -28,15 +29,14 @@ describe('integration tests', function () {
       knexConfig: knexConfig
     });
 
-    before(function () {
-      return session.createDb();
-    });
-
-    after(function () {
-      return session.destroy();
-    });
-
     describe(knexConfig.client, function () {
+      before(function () {
+        return session.createDb();
+      });
+
+      after(function () {
+        return session.destroy();
+      });
 
       require('./find')(session);
       require('./insert')(session);
@@ -47,7 +47,6 @@ describe('integration tests', function () {
       require('./unrelate')(session);
       require('./eager')(session);
       require('./transactions')(session);
-
     });
   });
 


### PR DESCRIPTION
before() calls creating integration test DBs were outside of all describes() running the tests on each database. This caused all integration tests to not be run even if just one database connection could not be made.

Basically I was running tests without mysql and got just error:

```
Mikaels-MacBook-Pro:moron.js mikaelle$ npm test

> moron@0.1.2 test /Users/mikaelle/Projects/Vincit/moron.js
> istanbul --config=.istanbul.yml cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive tests

Loading config: /Users/mikaelle/Projects/Vincit/moron.js/.istanbul.yml


  integration tests
Knex:Error Pool2 - Error: connect ECONNREFUSED
Knex:Error Pool2 - Error: connect ECONNREFUSED
    1) "before all" hook

  MoronModel
    ✓ should parse relations into Model instances and remove them from database representation (7ms)
    ✓ if jsonSchema is given, should remove all but schema properties from database representation (16ms)
    ✓ should convert objects to json based on jsonSchema type
    ✓ should convert objects to json based on jsonAttributes array
    ...
```

After fix: 

```
Mikaels-MacBook-Pro:moron.js mikaelle$ npm test

> moron@0.1.2 test /Users/mikaelle/Projects/Vincit/moron.js
> istanbul --config=.istanbul.yml cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive tests

Loading config: /Users/mikaelle/Projects/Vincit/moron.js/.istanbul.yml


  integration tests
Knex:Error Pool2 - Error: connect ECONNREFUSED
Knex:Error Pool2 - Error: connect ECONNREFUSED
    sqlite3
      MoronModel find queries
        .query()
          ✓ should return all rows when no knex methods are chained (16ms)
          knex methods
            ✓ .select()
            ✓ .where()
  ...

        ✓ should fail without models
        ✓ should fail if one of the model classes is not a subclass of MoronModel
        ✓ should fail if all ModelClasses are not bound to the same knex connection
        ✓ should commit transaction if no errors occur (13ms)
        ✓ should rollback if an error occurs (1) (10ms)
        ✓ should rollback if an error occurs (2) (8ms)
        ✓ should skip queries after rollback (16ms)
    mysql
      1) "before all" hook

  MoronModel
    ✓ should parse relations into Model instances and remove them from database representation (7ms)
    ✓ if jsonSchema is given, should remove all but schema properties from database representation (10ms)
    ✓ should convert objects to json based on jsonSchema type (24ms)
    ✓ should convert objects to json based on jsonAttributes array (9ms)

  MoronModelBase
    extend
      ✓ should create a subclass
      ✓ should create a subclass of subclass
      ✓ should fail if the subclass constructor has no name
  ...
```

So just one platform fails anymore.