### PR TITLE
Add .js suffix for babel-node in "npm start"

### DIFF
--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -4,7 +4,7 @@
   "description": "Moron.js express ES7 example",
   "main": "app.js",
   "scripts": {
-    "start": "node_modules/babel/bin/babel-node --stage 0 app"
+    "start": "node_modules/babel/bin/babel-node.js --stage 0 app"
   },
   "author": "Sami Koskimäki",
   "license": "MIT",


### PR DESCRIPTION
No biggie – fixes https://github.com/Vincit/moron.js/issues/27